### PR TITLE
Add benchmark for sort vs sort_by

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Each idiom has a corresponding code example that resides in [code](code).
 
 ## Measurement Tool
 
-We use [benchee](https://github.com/PragTob/benchee) (0.7+).
+We use [benchee](https://github.com/PragTob/benchee).
 
 ## Contributing
 
@@ -140,28 +140,33 @@ in the associative data structure. The speed differences are minimal.
 
 ```
 ↪ mix run code/general/sort_vs_sort_by.exs
+Operating System: macOS
+CPU Information: Intel(R) Core(TM) i7-4558U CPU @ 2.80GHz
+Number of Available Cores: 4
+Available memory: 17.179869184 GB
 Elixir 1.4.4
 Erlang 19.3
 Benchmark suite executing with the following configuration:
-warmup: 2.0s
-time: 10.0s
+warmup: 2.00 s
+time: 10.00 s
 parallel: 1
 inputs: none specified
-Estimated total run time: 36.0s
+Estimated total run time: 36.00 s
+
 
 Benchmarking sort/1...
 Benchmarking sort/2...
 Benchmarking sort_by/2...
 
 Name                ips        average  deviation         median
-sort/1           5.26 K      190.18 μs    ±17.11%      178.00 μs
-sort/2           5.02 K      199.39 μs    ±16.09%      187.00 μs
-sort_by/2        4.82 K      207.35 μs    ±19.17%      197.00 μs
+sort/1           5.20 K      192.27 μs    ±18.76%      182.00 μs
+sort/2           4.93 K      202.81 μs    ±24.58%      191.00 μs
+sort_by/2        4.81 K      207.88 μs    ±17.71%      198.00 μs
 
 Comparison:
-sort/1           5.26 K
-sort/2           5.02 K - 1.05x slower
-sort_by/2        4.82 K - 1.09x slower
+sort/1           5.20 K
+sort/2           4.93 K - 1.05x slower
+sort_by/2        4.81 K - 1.08x slower
 ```
 
 ## Something went wrong

--- a/README.md
+++ b/README.md
@@ -132,6 +132,38 @@ split                    274.56 K
 splitter |> to_list       31.03 K - 8.85x slower
 ```
 
+#### `sort` vs. `sort_by` [code](code/general/sort_vs_sort_by.exs)
+
+Sorting a list of maps or keyword lists can be done in various ways,
+given that the key-value you want to sort on is the first one defined
+in the associative data structure. The speed differences are minimal.
+
+```
+↪ mix run code/general/sort_vs_sort_by.exs
+Elixir 1.4.4
+Erlang 19.3
+Benchmark suite executing with the following configuration:
+warmup: 2.0s
+time: 10.0s
+parallel: 1
+inputs: none specified
+Estimated total run time: 36.0s
+
+Benchmarking sort/1...
+Benchmarking sort/2...
+Benchmarking sort_by/2...
+
+Name                ips        average  deviation         median
+sort/1           5.26 K      190.18 μs    ±17.11%      178.00 μs
+sort/2           5.02 K      199.39 μs    ±16.09%      187.00 μs
+sort_by/2        4.82 K      207.35 μs    ±19.17%      197.00 μs
+
+Comparison:
+sort/1           5.26 K
+sort/2           5.02 K - 1.05x slower
+sort_by/2        4.82 K - 1.09x slower
+```
+
 ## Something went wrong
 
 Something look wrong to you? :cry: Have a better example? :heart_eyes: Excellent!

--- a/code/general/sort_vs_sort_by.exs
+++ b/code/general/sort_vs_sort_by.exs
@@ -1,0 +1,33 @@
+defmodule Card, do: defstruct [:rank, :suit]
+
+defmodule Sort.Fast do
+  def sort(enumerable), do: Enum.sort(enumerable)
+end
+
+defmodule Sort.Slow do
+  def sort(enumerable), do: Enum.sort_by(enumerable, &(&1.rank))
+end
+
+defmodule Sort.Slowest do
+  def sort(enumerable), do: Enum.sort(enumerable, &(&1.rank) <= (&2.rank))
+end
+
+defmodule Sort.Benchmark do
+  def benchmark do
+    Benchee.run(%{
+      "sort/1" => fn -> bench(Sort.Fast) end,
+      "sort_by/2" => fn -> bench(Sort.Slow) end,
+      "sort/2" => fn -> bench(Sort.Slowest) end,
+    }, time: 10, print: [fast_warning: false])
+  end
+
+  defp bench(module) do
+    cards = Enum.map 1..100, fn _ ->
+      %Card{rank: Enum.random(0..100), suit: Enum.random(~w[red green blue]a)}
+    end
+
+    module.sort(cards)
+  end
+end
+
+Sort.Benchmark.benchmark()

--- a/code/general/sort_vs_sort_by.exs
+++ b/code/general/sort_vs_sort_by.exs
@@ -5,19 +5,19 @@ defmodule Sort.Fast do
 end
 
 defmodule Sort.Slow do
-  def sort(enumerable), do: Enum.sort_by(enumerable, &(&1.rank))
+  def sort(enumerable), do: Enum.sort(enumerable, &(&1.rank) <= (&2.rank))
 end
 
 defmodule Sort.Slowest do
-  def sort(enumerable), do: Enum.sort(enumerable, &(&1.rank) <= (&2.rank))
+  def sort(enumerable), do: Enum.sort_by(enumerable, &(&1.rank))
 end
 
 defmodule Sort.Benchmark do
   def benchmark do
     Benchee.run(%{
       "sort/1" => fn -> bench(Sort.Fast) end,
-      "sort_by/2" => fn -> bench(Sort.Slow) end,
-      "sort/2" => fn -> bench(Sort.Slowest) end,
+      "sort/2" => fn -> bench(Sort.Slow) end,
+      "sort_by/2" => fn -> bench(Sort.Slowest) end,
     }, time: 10, print: [fast_warning: false])
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,6 @@ defmodule FastElixir.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:benchee, git: "https://github.com/PragTob/benchee.git"}]
+    [{:benchee, github: "PragTob/benchee"}]
   end
 end


### PR DESCRIPTION
Note this benchmark uses Elixir 1.4.4 and a machine with different specs, so I've included an extra commit to loosen the benchmark criteria.