### PR TITLE
Use a current released benchee version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,6 @@ defmodule FastElixir.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:benchee, github: "PragTob/benchee"}]
+    [{:benchee, "~> 0.12"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"benchee": {:git, "https://github.com/PragTob/benchee.git", "ed414d5fbd692c5f6fb5e54d5ab4a1afa1fb5283", []},
+%{"benchee": {:hex, :benchee, "0.12.1", "1286a79bab2f1899220134daf9a695586af00ea71968e6cd89d3d3afdf7cecba", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
   "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], []},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}


### PR DESCRIPTION
:)

(noticed the wrong memory information in the README examples, didn't rerun all the benchmarks though but could start doing that)