### PR TITLE
Compare membership

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 21.2.6
-elixir 1.8.1-otp-21
+erlang 22.0.1
+elixir 1.8.2-otp-22

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,11 @@ Thank you for contributing! Let's get you started!
 
 1. Fork and clone the repository
 
-2. Install dependencies: `mix deps.get`
+1. Install the Elixir/Erlang versions in [`.tool-versions`](.tool-versions)
 
-3. Write a benchmark using the following template:
+1. Install dependencies: `mix deps.get`
+
+1. Write a benchmark using the following template:
 
     ```elixir
     defmodule IdiomName.Fast do
@@ -37,8 +39,8 @@ Thank you for contributing! Let's get you started!
     IdiomName.Benchmark.benchmark()
     ```
 
-4. Run your benchmark: `mix run code/<category>/<benchmark>.exs`
+1. Run your benchmark: `mix run code/<category>/<benchmark>.exs`
 
-5. Add the output along with a description to the [README](README.md).
+1. Add the output along with a description to the [README](README.md)
 
-6. Open a Pull Request!
+1. Open a Pull Request!

--- a/code/general/membership.exs
+++ b/code/general/membership.exs
@@ -1,0 +1,68 @@
+defmodule Membership.NewMapSetMember do
+  def check_membership(range, list, _mapset) do
+    find = Enum.random(range)
+    mapset = MapSet.new(list)
+    MapSet.member?(mapset, find)
+  end
+end
+
+defmodule Membership.MapSetMember do
+  def check_membership(range, _list, mapset) do
+    find = Enum.random(range)
+    MapSet.member?(mapset, find)
+  end
+end
+
+defmodule Membership.EnumMember do
+  def check_membership(range, list, _mapset) do
+    find = Enum.random(range)
+    Enum.member?(list, find)
+  end
+end
+
+defmodule Membership.EnumAny do
+  def check_membership(range, list, _mapset) do
+    find = Enum.random(range)
+    Enum.any?(list, &(&1 == find))
+  end
+end
+
+defmodule Membership.In do
+  def check_membership(range, list, _mapset) do
+    find = Enum.random(range)
+    find in list
+  end
+end
+
+defmodule Membership.Benchmark do
+  @inputs %{
+    "Large (pass)" => {1..1_000_000, Enum.shuffle(1..1_000_000), MapSet.new(1..1_000_000)},
+    "Large (fail)" =>
+      {1_000_001..2_000_000, Enum.shuffle(1..1_000_000), MapSet.new(1..1_000_000)},
+    "Medium (pass)" => {1..10_000, Enum.shuffle(1..10_000), MapSet.new(1..10_000)},
+    "Medium (fail)" => {10_001..20_000, Enum.shuffle(1..10_000), MapSet.new(1..10_000)},
+    "Small (pass)" => {1..100, Enum.shuffle(1..100), MapSet.new(1..100)},
+    "Small (fail)" => {101..200, Enum.shuffle(1..100), MapSet.new(1..100)}
+  }
+
+  def benchmark do
+    Benchee.run(
+      %{
+        "New MapSet + MapSet.member?" => fn input -> bench(Membership.NewMapSetMember, input) end,
+        "MapSet.member?" => fn input -> bench(Membership.MapSetMember, input) end,
+        "Enum.member?" => fn input -> bench(Membership.EnumMember, input) end,
+        "Enum.any?" => fn input -> bench(Membership.EnumAny, input) end,
+        "x in y" => fn input -> bench(Membership.In, input) end
+      },
+      time: 10,
+      inputs: @inputs,
+      print: [fast_warning: false]
+    )
+  end
+
+  defp bench(module, {range, list, mapset}) do
+    module.check_membership(range, list, mapset)
+  end
+end
+
+Membership.Benchmark.benchmark()

--- a/code/general/membership.exs
+++ b/code/general/membership.exs
@@ -36,13 +36,9 @@ end
 
 defmodule Membership.Benchmark do
   @inputs %{
-    "Large (pass)" => {1..1_000_000, Enum.shuffle(1..1_000_000), MapSet.new(1..1_000_000)},
-    "Large (fail)" =>
-      {1_000_001..2_000_000, Enum.shuffle(1..1_000_000), MapSet.new(1..1_000_000)},
-    "Medium (pass)" => {1..10_000, Enum.shuffle(1..10_000), MapSet.new(1..10_000)},
-    "Medium (fail)" => {10_001..20_000, Enum.shuffle(1..10_000), MapSet.new(1..10_000)},
-    "Small (pass)" => {1..100, Enum.shuffle(1..100), MapSet.new(1..100)},
-    "Small (fail)" => {101..200, Enum.shuffle(1..100), MapSet.new(1..100)}
+    "Large" => {1..1_000_000, Enum.shuffle(1..1_000_000), MapSet.new(1..1_000_000)},
+    "Medium" => {1..10_000, Enum.shuffle(1..10_000), MapSet.new(1..10_000)},
+    "Small" => {1..100, Enum.shuffle(1..100), MapSet.new(1..100)}
   }
 
   def benchmark do

--- a/mix.exs
+++ b/mix.exs
@@ -12,13 +12,6 @@ defmodule FastElixir.Mixfile do
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
-  def application do
-    [applications: [:logger]]
-  end
-
   # Type "mix help deps" for more information
   defp deps do
     [{:benchee, "~> 1.0"}]

--- a/mix.exs
+++ b/mix.exs
@@ -2,12 +2,14 @@ defmodule FastElixir.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :fast_elixir,
-     version: "0.1.0",
-     elixir: "~> 1.4",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+    [
+      app: :fast_elixir,
+      version: "0.1.0",
+      elixir: "~> 1.6",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application

--- a/mix.exs
+++ b/mix.exs
@@ -17,16 +17,8 @@ defmodule FastElixir.Mixfile do
     [applications: [:logger]]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
+  # Type "mix help deps" for more information
   defp deps do
-    [{:benchee, "~> 0.14"}]
+    [{:benchee, "~> 1.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "benchee": {:hex, :benchee, "0.14.0", "f771f587c48b4824b497e2a3e374f75e93ef01fc329873b089a3f5dd961b80b8", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
-  "deep_merge": {:hex, :deep_merge, "0.2.0", "c1050fa2edf4848b9f556fba1b75afc66608a4219659e3311d9c9427b5b680b3", [:mix], [], "hexpm"},
+  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
 }


### PR DESCRIPTION
Branched off of `update-elixir-erlang`, will rebase once that's been merged.

Compares various methods for checking whether an element is a member of an enumerable.

I'll add the README section once the benchmark code gets a thumbs up.

I removed benchmarks that tested misses (i.e. element not a member) to keep the results more focused, but can revert 917386a if we think it's useful to include. Basically, `MapSet.member?/2` is way more performant for large _n_.

<details>
<summary>Click to see full benchmark results</summary>

```shell
Operating System: macOS
CPU Information: Intel(R) Core(TM) i5-7267U CPU @ 3.10GHz
Number of Available Cores: 4
Available memory: 16 GB
Elixir 1.8.2
Erlang 22.0.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 0 ns
parallel: 1
inputs: Large (in range), Large (out of range), Medium (in range), Medium (out of range), Small (in range), Small (out of range)
Estimated total run time: 6 min

Benchmarking Enum.any? with input Large (in range)...
Benchmarking Enum.any? with input Large (out of range)...
Benchmarking Enum.any? with input Medium (in range)...
Benchmarking Enum.any? with input Medium (out of range)...
Benchmarking Enum.any? with input Small (in range)...
Benchmarking Enum.any? with input Small (out of range)...
Benchmarking Enum.member? with input Large (in range)...
Benchmarking Enum.member? with input Large (out of range)...
Benchmarking Enum.member? with input Medium (in range)...
Benchmarking Enum.member? with input Medium (out of range)...
Benchmarking Enum.member? with input Small (in range)...
Benchmarking Enum.member? with input Small (out of range)...
Benchmarking MapSet.member? with input Large (in range)...
Benchmarking MapSet.member? with input Large (out of range)...
Benchmarking MapSet.member? with input Medium (in range)...
Benchmarking MapSet.member? with input Medium (out of range)...
Benchmarking MapSet.member? with input Small (in range)...
Benchmarking MapSet.member? with input Small (out of range)...
Benchmarking New MapSet + MapSet.member? with input Large (in range)...
Benchmarking New MapSet + MapSet.member? with input Large (out of range)...
Benchmarking New MapSet + MapSet.member? with input Medium (in range)...
Benchmarking New MapSet + MapSet.member? with input Medium (out of range)...
Benchmarking New MapSet + MapSet.member? with input Small (in range)...
Benchmarking New MapSet + MapSet.member? with input Small (out of range)...
Benchmarking x in y with input Large (in range)...
Benchmarking x in y with input Large (out of range)...
Benchmarking x in y with input Medium (in range)...
Benchmarking x in y with input Medium (out of range)...
Benchmarking x in y with input Small (in range)...
Benchmarking x in y with input Small (out of range)...

##### With input Large (in range) #####
Name                                  ips        average  deviation         median         99th %
MapSet.member?                   990.69 K        1.01 μs  ±4443.46%           1 μs           2 μs
Enum.member?                       1.44 K      695.55 μs    ±59.44%         687 μs     1427.72 μs
x in y                             1.32 K      756.34 μs    ±66.04%         727 μs        1984 μs
Enum.any?                        0.0834 K    11986.08 μs    ±61.53%    12136.01 μs    29520.32 μs
New MapSet + MapSet.member?     0.00452 K   221097.33 μs    ±11.90%   229234.50 μs      307566 μs

Comparison:
MapSet.member?                   990.69 K
Enum.member?                       1.44 K - 689.08x slower +694.54 μs
x in y                             1.32 K - 749.31x slower +755.33 μs
Enum.any?                        0.0834 K - 11874.55x slower +11985.08 μs
New MapSet + MapSet.member?     0.00452 K - 219039.93x slower +221096.32 μs

##### With input Large (out of range) #####
Name                                  ips        average  deviation         median         99th %
MapSet.member?                 1084461.54     0.00092 ms  ±4546.06%     0.00100 ms     0.00200 ms
Enum.member?                       695.59        1.44 ms    ±10.06%        1.40 ms        2.15 ms
x in y                             645.85        1.55 ms    ±26.14%        1.45 ms        2.73 ms
Enum.any?                           42.58       23.48 ms    ±14.22%       22.57 ms       37.92 ms
New MapSet + MapSet.member?          4.55      219.98 ms    ±11.65%      227.22 ms      307.94 ms

Comparison:
MapSet.member?                 1084461.54
Enum.member?                       695.59 - 1559.06x slower +1.44 ms
x in y                             645.85 - 1679.13x slower +1.55 ms
Enum.any?                           42.58 - 25467.02x slower +23.48 ms
New MapSet + MapSet.member?          4.55 - 238561.55x slower +219.98 ms

##### With input Medium (in range) #####
Name                                  ips        average  deviation         median         99th %
MapSet.member?                  1313.78 K        0.76 μs  ±5227.46%           1 μs           1 μs
Enum.member?                     148.53 K        6.73 μs   ±155.66%           7 μs          14 μs
x in y                           140.91 K        7.10 μs   ±255.14%           7 μs          17 μs
Enum.any?                          7.99 K      125.21 μs   ±136.51%         113 μs      417.00 μs
New MapSet + MapSet.member?        0.75 K     1337.37 μs     ±6.99%        1310 μs     1780.66 μs

Comparison:
MapSet.member?                  1313.78 K
Enum.member?                     148.53 K - 8.85x slower +5.97 μs
x in y                           140.91 K - 9.32x slower +6.34 μs
Enum.any?                          7.99 K - 164.50x slower +124.45 μs
New MapSet + MapSet.member?        0.75 K - 1757.01x slower +1336.61 μs

##### With input Medium (out of range) #####
Name                                  ips        average  deviation         median         99th %
MapSet.member?                  1324.94 K        0.75 μs  ±5340.65%           1 μs           1 μs
Enum.member?                      77.05 K       12.98 μs    ±73.50%          13 μs          19 μs
x in y                            71.57 K       13.97 μs   ±194.29%          13 μs          27 μs
Enum.any?                          4.49 K      222.85 μs    ±44.82%         200 μs         455 μs
New MapSet + MapSet.member?        0.74 K     1351.54 μs     ±9.65%        1316 μs     1941.11 μs

Comparison:
MapSet.member?                  1324.94 K
Enum.member?                      77.05 K - 17.19x slower +12.22 μs
x in y                            71.57 K - 18.51x slower +13.22 μs
Enum.any?                          4.49 K - 295.27x slower +222.10 μs
New MapSet + MapSet.member?        0.74 K - 1790.71x slower +1350.78 μs

##### With input Small (in range) #####
Name                                  ips        average  deviation         median         99th %
MapSet.member?                     1.38 M      724.38 ns  ±5501.26%        1000 ns        1000 ns
Enum.member?                       1.32 M      754.88 ns  ±5251.67%        1000 ns        1000 ns
x in y                             1.28 M      782.09 ns  ±5340.69%        1000 ns        1000 ns
Enum.any?                          0.59 M     1705.19 ns  ±1344.36%        2000 ns        3000 ns
New MapSet + MapSet.member?       0.153 M     6532.43 ns   ±221.05%        6000 ns       11000 ns

Comparison:
MapSet.member?                     1.38 M
Enum.member?                       1.32 M - 1.04x slower +30.50 ns
x in y                             1.28 M - 1.08x slower +57.71 ns
Enum.any?                          0.59 M - 2.35x slower +980.81 ns
New MapSet + MapSet.member?       0.153 M - 9.02x slower +5808.05 ns

##### With input Small (out of range) #####
Name                                  ips        average  deviation         median         99th %
MapSet.member?                     1.39 M      721.88 ns  ±5766.50%        1000 ns        1000 ns
Enum.member?                       1.24 M      806.11 ns  ±4965.41%        1000 ns        1000 ns
x in y                             1.19 M      837.44 ns  ±5384.61%        1000 ns        1000 ns
Enum.any?                          0.37 M     2730.09 ns   ±811.43%        3000 ns        4000 ns
New MapSet + MapSet.member?       0.140 M     7141.31 ns   ±378.30%        6000 ns       20000 ns

Comparison:
MapSet.member?                     1.39 M
Enum.member?                       1.24 M - 1.12x slower +84.23 ns
x in y                             1.19 M - 1.16x slower +115.57 ns
Enum.any?                          0.37 M - 3.78x slower +2008.22 ns
New MapSet + MapSet.member?       0.140 M - 9.89x slower +6419.43 ns
```
</details>